### PR TITLE
Added copyright settings and updated .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,13 +19,17 @@ bin/
 !**/src/test/**/bin/
 
 ### IntelliJ IDEA ###
-.idea
+.idea/*
+!.idea/copyright
+!.idea/scopes
+
 *.iws
 *.iml
 *.ipr
 out/
 !**/src/main/**/out/
 !**/src/test/**/out/
+
 
 ### NetBeans ###
 /nbproject/private/

--- a/.idea/copyright/MPL2_0.xml
+++ b/.idea/copyright/MPL2_0.xml
@@ -1,0 +1,7 @@
+<component name="CopyrightManager">
+  <copyright>
+    <option name="keyword" value="This Source Code Form" />
+    <option name="notice" value="This Source Code Form is subject to the terms of the Mozilla Public&#10;License, v. 2.0. If a copy of the MPL was not distributed with this&#10;file, You can obtain one at https://mozilla.org/MPL/2.0/." />
+    <option name="myName" value="MPL2.0" />
+  </copyright>
+</component>

--- a/.idea/copyright/profiles_settings.xml
+++ b/.idea/copyright/profiles_settings.xml
@@ -1,0 +1,7 @@
+<component name="CopyrightManager">
+  <settings default="MPL2.0">
+    <module2copyright>
+      <element module="Copyright-Scope" copyright="MPL2.0" />
+    </module2copyright>
+  </settings>
+</component>

--- a/.idea/scopes/Copyright_Scope.xml
+++ b/.idea/scopes/Copyright_Scope.xml
@@ -1,0 +1,3 @@
+<component name="DependencyValidationManager">
+  <scope name="Copyright-Scope" pattern="(file[Tachidesk-VaadinUI.main]:*/||file[Tachidesk-VaadinUI.test]:*/||file[Tachidesk-VaadinUI]:frontend//*||file[Tachidesk-VaadinUI]:build.gradle||file[Tachidesk-VaadinUI]:settings.gradle)&amp;&amp;!file[Tachidesk-VaadinUI]:vite.config.ts&amp;&amp;!file[Tachidesk-VaadinUI]:gradlew&amp;&amp;!file[Tachidesk-VaadinUI]:gradle/wrapper/*&amp;&amp;!file[Tachidesk-VaadinUI]:gradle/wrapper//*" />
+</component>


### PR DESCRIPTION
The copyright settings for IntelliJ have been set up under the MPL2.0 license. This includes creating new profile_settings.xml, MPL2_0.xml, and Copyright_Scope.xml files. The .gitignore file was also updated to include these settings. This change is necessary to ensure compliance with the licensing requirements and to prevent copyright issues.